### PR TITLE
feat: support access_token in signed or non-signed cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Per [RFC6750](https://datatracker.ietf.org/doc/html/rfc6750) this module will at
 - The key `access_token` in the request body.
 - The key `access_token` in the request query params.
 - The value from the header `Authorization: Bearer <token>`.
+- (Optional) Get a token from cookies header with key `access_token`.
 
 If a token is found, it will be stored on `ctx.request.token`. If one has been provided in more than one location, this will abort the request immediately by sending code 400 (per [RFC6750]).
 
@@ -50,6 +51,22 @@ app.use(
     queryKey: 'access_token',
     headerKey: 'Bearer',
     reqKey: 'token',
+  }),
+);
+```
+
+Get token from cookie key (it can be signed or not)
+
+**Warning**: by **NOT** passing `{ signed: true }` you are accepting a non signed cookie and an attacker might spoof the cookies. so keep in mind to use signed cookies
+
+```js
+app.use(
+  bearerToken({
+    cookie: {
+      signed: true, // if passed true you must pass secret otherwise will throw error
+      secret: 'YOUR_APP_SECRET',
+      key: 'access_token', // default value
+    },
   }),
 );
 ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,25 @@
+const parseCookie = require('cookie').parse;
+const decodeCookie = require('cookie-parser').signedCookie;
+
+const getCookie = (serializedCookies, key) =>
+  parseCookie(serializedCookies)[key] || false;
+
 module.exports = function bearerToken(opts = {}) {
   const queryKey = opts.queryKey || 'access_token';
   const bodyKey = opts.bodyKey || 'access_token';
   const headerKey = opts.headerKey || 'Bearer';
   const reqKey = opts.reqKey || 'token';
+  const cookie = opts.cookie || false;
+
+  if (cookie && !cookie.key) {
+    cookie.key = 'access_token';
+  }
+
+  if (cookie && cookie.signed && !cookie.secret) {
+    throw new Error(
+      '[koa-bearer-token]: You must provide a secret token to cookie attribute, or disable signed property',
+    );
+  }
 
   return (ctx, next) => {
     const { body, header, query } = ctx.request;
@@ -20,11 +37,28 @@ module.exports = function bearerToken(opts = {}) {
       count += 1;
     }
 
-    if (header && header.authorization) {
-      const parts = header.authorization.split(' ');
-      if (parts.length === 2 && parts[0] === headerKey) {
-        [, token] = parts;
-        count += 1;
+    if (header) {
+      if (header.authorization) {
+        const parts = header.authorization.split(' ');
+        if (parts.length === 2 && parts[0] === headerKey) {
+          [, token] = parts;
+          count += 1;
+        }
+      }
+
+      // cookie
+      if (cookie && header.cookie) {
+        const plainCookie = getCookie(header.cookie || '', cookie.key); // seeks the key
+        if (plainCookie) {
+          const cookieToken = cookie.signed
+            ? decodeCookie(plainCookie, cookie.secret)
+            : plainCookie;
+
+          if (cookieToken) {
+            token = cookieToken;
+            count += 1;
+          }
+        }
       }
     }
 
@@ -32,7 +66,7 @@ module.exports = function bearerToken(opts = {}) {
     // in more than one place in a single request.
     if (count > 1) {
       ctx.throw(400, 'token_invalid', {
-        message: `${queryKey} MUST NOT be provided in more than one place`,
+        message: `token MUST NOT be provided in more than one place`,
       });
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1642,6 +1642,38 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        }
+      }
+    },
+    "cookie-signature": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz",
+      "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==",
+      "dev": true
+    },
     "cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,12 @@
     "prettier": "prettier --write --list-different .",
     "prettier:check": "prettier --check ."
   },
+  "dependencies": {
+    "cookie": "^0.4.1",
+    "cookie-parser": "^1.4.5"
+  },
   "devDependencies": {
+    "cookie-signature": "^1.1.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
Get token from cookie key (it can be signed or not)

```js
app.use(
  bearerToken({
    cookie: {
      signed: true, // if passed true you must pass secret otherwise will throw error
      secret: 'YOUR_APP_SECRET',
      key: 'access_token', // default value
    },
  }),
);
```